### PR TITLE
Handle tapped check‑in notifications

### DIFF
--- a/wevebeenherebefore/AppDelegate.swift
+++ b/wevebeenherebefore/AppDelegate.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+import UserNotifications
+
+class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        let category = UNNotificationCategory(identifier: "EPISODE_CHECKIN", actions: [], intentIdentifiers: [], options: [])
+        UNUserNotificationCenter.current().setNotificationCategories([category])
+        return true
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+        NotificationManager.shared.handleNotificationResponse(response)
+        completionHandler()
+    }
+}

--- a/wevebeenherebefore/wevebeenherebeforeApp.swift
+++ b/wevebeenherebefore/wevebeenherebeforeApp.swift
@@ -10,6 +10,7 @@ import SwiftData
 
 @main
 struct wevebeenherebeforeApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     var sharedModelContainer: ModelContainer = {
         let schema = Schema([
             Card.self,
@@ -29,6 +30,7 @@ struct wevebeenherebeforeApp: App {
     var body: some Scene {
         WindowGroup {
             ResilienceView()
+                .environmentObject(NotificationManager.shared)
         }
         .modelContainer(sharedModelContainer)
     }


### PR DESCRIPTION
## Summary
- add `AppDelegate` that registers `UNUserNotificationCenter` delegate
- enrich `NotificationManager` with navigation handling
- observe pending notifications in `ResilienceView`
- hook `NotificationManager` up to the SwiftUI `App`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6845845c32f08331b1f81fa5b65f3d7c